### PR TITLE
Refactored server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,21 +29,21 @@ io.on('connection',function(socket){
         };
         socket.emit('allplayers',getAllPlayers());
         socket.broadcast.emit('newplayer',socket.player);
+
+        socket.on('click',function(data){
+            console.log('click to '+data.x+', '+data.y);
+            socket.player.x = data.x;
+            socket.player.y = data.y;
+            io.emit('move',socket.player);
+        });
+
+        socket.on('disconnect',function(){
+            io.emit('remove',socket.player.id);
+        });
     });
 
     socket.on('test',function(){
         console.log('test received');
-    });
-
-    socket.on('click',function(data){
-        console.log('click to '+data.x+', '+data.y);
-        socket.player.x = data.x;
-        socket.player.y = data.y;
-        io.emit('move',socket.player);
-    });
-
-    socket.on('disconnect',function(){
-        io.emit('remove',socket.player.id);
     });
 });
 


### PR DESCRIPTION
Moved socket.on click and socket.on disconnect within socket.on newplayer so that these functions cannot be called before socket.player is created.

Calling click or disconnect before the player is created causes the server to crash 